### PR TITLE
Replace the hardcoded ip address with a dns lookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ heapless = "0.7.16"
 esp-backtrace = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32c3","log"] }
 embedded-svc = { version = "0.25.0", default-features = false}
-embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet", "proto-ipv6", "log"] }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet", "proto-ipv6", "log", "dns"] }
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embassy-time       = { version = "0.1.1", features = ["nightly"] }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }


### PR DESCRIPTION
I can't actually test that it works because my ISP is having issue right now :upside_down_face:.

I can test at least that the error handling works :D.

For my router I also needed to bump the number of DNS servers smoltcp has capacity for with:

```toml
# .cargo/config.toml
[env]
SMOLTCP_DNS_MAX_SERVER_COUNT = "3"
```
Be warned that you have to do a clean build for those changes to take effect, see: https://github.com/rust-lang/cargo/issues/10358